### PR TITLE
newscraper - historical transactions - visualisation

### DIFF
--- a/SnP_tickers_sector.csv
+++ b/SnP_tickers_sector.csv
@@ -1,0 +1,504 @@
+Symbol,Security,GICS Sector,GICS Sub-Industry,Headquarters Location,Date added,CIK,Founded
+MMM,3M,Industrials,Industrial Conglomerates,"Saint Paul, Minnesota",1957-03-04,66740,1902
+AOS,A. O. Smith,Industrials,Building Products,"Milwaukee, Wisconsin",2017-07-26,91142,1916
+ABT,Abbott,Health Care,Health Care Equipment,"North Chicago, Illinois",1957-03-04,1800,1888
+ABBV,AbbVie,Health Care,Biotechnology,"North Chicago, Illinois",2012-12-31,1551152,2013 (1888)
+ACN,Accenture,Information Technology,IT Consulting & Other Services,"Dublin, Ireland",2011-07-06,1467373,1989
+ADBE,Adobe Inc.,Information Technology,Application Software,"San Jose, California",1997-05-05,796343,1982
+AMD,Advanced Micro Devices,Information Technology,Semiconductors,"Santa Clara, California",2017-03-20,2488,1969
+AES,AES Corporation,Utilities,Independent Power Producers & Energy Traders,"Arlington, Virginia",1998-10-02,874761,1981
+AFL,Aflac,Financials,Life & Health Insurance,"Columbus, Georgia",1999-05-28,4977,1955
+A,Agilent Technologies,Health Care,Life Sciences Tools & Services,"Santa Clara, California",2000-06-05,1090872,1999
+APD,Air Products and Chemicals,Materials,Industrial Gases,"Allentown, Pennsylvania",1985-04-30,2969,1940
+ABNB,Airbnb,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","San Francisco, California",2023-09-18,1559720,2008
+AKAM,Akamai,Information Technology,Internet Services & Infrastructure,"Cambridge, Massachusetts",2007-07-12,1086222,1998
+ALB,Albemarle Corporation,Materials,Specialty Chemicals,"Charlotte, North Carolina",2016-07-01,915913,1994
+ARE,Alexandria Real Estate Equities,Real Estate,Office REITs,"Pasadena, California",2017-03-20,1035443,1994
+ALGN,Align Technology,Health Care,Health Care Supplies,"Tempe, Arizona",2017-06-19,1097149,1997
+ALLE,Allegion,Industrials,Building Products,"Dublin, Ireland",2013-12-02,1579241,1908
+LNT,Alliant Energy,Utilities,Electric Utilities,"Madison, Wisconsin",2016-07-01,352541,1917
+ALL,Allstate,Financials,Property & Casualty Insurance,"Northbrook, Illinois",1995-07-13,899051,1931
+GOOGL,Alphabet Inc. (Class A),Communication Services,Interactive Media & Services,"Mountain View, California",2014-04-03,1652044,1998
+GOOG,Alphabet Inc. (Class C),Communication Services,Interactive Media & Services,"Mountain View, California",2006-04-03,1652044,1998
+MO,Altria,Consumer Staples,Tobacco,"Richmond, Virginia",1957-03-04,764180,1985
+AMZN,Amazon,Consumer Discretionary,Broadline Retail,"Seattle, Washington",2005-11-18,1018724,1994
+AMCR,Amcor,Materials,Paper & Plastic Packaging Products & Materials,"Warmley, Bristol, United Kingdom",2019-06-07,1748790,2019 (1860)
+AEE,Ameren,Utilities,Multi-Utilities,"St. Louis, Missouri",1991-09-19,1002910,1902
+AAL,American Airlines Group,Industrials,Passenger Airlines,"Fort Worth, Texas",2015-03-23,6201,1934
+AEP,American Electric Power,Utilities,Electric Utilities,"Columbus, Ohio",1957-03-04,4904,1906
+AXP,American Express,Financials,Consumer Finance,"New York City, New York",1976-06-30,4962,1850
+AIG,American International Group,Financials,Multi-line Insurance,"New York City, New York",1980-03-31,5272,1919
+AMT,American Tower,Real Estate,Telecom Tower REITs,"Boston, Massachusetts",2007-11-19,1053507,1995
+AWK,American Water Works,Utilities,Water Utilities,"Camden, New Jersey",2016-03-04,1410636,1886
+AMP,Ameriprise Financial,Financials,Asset Management & Custody Banks,"Minneapolis, Minnesota",2005-10-03,820027,1894
+AME,Ametek,Industrials,Electrical Components & Equipment,"Berwyn, Pennsylvania",2013-09-23,1037868,1930
+AMGN,Amgen,Health Care,Biotechnology,"Thousand Oaks, California",1992-01-02,318154,1980
+APH,Amphenol,Information Technology,Electronic Components,"Wallingford, Connecticut",2008-09-30,820313,1932
+ADI,Analog Devices,Information Technology,Semiconductors,"Wilmington, Massachusetts",1999-10-12,6281,1965
+ANSS,Ansys,Information Technology,Application Software,"Canonsburg, Pennsylvania",2017-06-19,1013462,1969
+AON,Aon,Financials,Insurance Brokers,"London, UK",1996-04-23,315293,1982 (1919)
+APA,APA Corporation,Energy,Oil & Gas Exploration & Production,"Houston, Texas",1997-07-28,1841666,1954
+AAPL,Apple Inc.,Information Technology,"Technology Hardware, Storage & Peripherals","Cupertino, California",1982-11-30,320193,1977
+AMAT,Applied Materials,Information Technology,Semiconductor Materials & Equipment,"Santa Clara, California",1995-03-16,6951,1967
+APTV,Aptiv,Consumer Discretionary,Automotive Parts & Equipment,"Dublin, Ireland",2012-12-24,1521332,1994
+ACGL,Arch Capital Group,Financials,Property & Casualty Insurance,"Hamilton, Bermuda",2022-11-01,947484,1995
+ADM,Archer-Daniels-Midland,Consumer Staples,Agricultural Products & Services,"Chicago, Illinois",1957-03-04,7084,1902
+ANET,Arista Networks,Information Technology,Communications Equipment,"Santa Clara, California",2018-08-28,1596532,2004
+AJG,Arthur J. Gallagher & Co.,Financials,Insurance Brokers,"Rolling Meadows, Illinois",2016-05-31,354190,1927
+AIZ,Assurant,Financials,Multi-line Insurance,"Atlanta, Georgia",2007-04-10,1267238,1892
+T,AT&T,Communication Services,Integrated Telecommunication Services,"Dallas, Texas",1983-11-30,732717,1983 (1885)
+ATO,Atmos Energy,Utilities,Gas Utilities,"Dallas, Texas",2019-02-15,731802,1906
+ADSK,Autodesk,Information Technology,Application Software,"San Francisco, California",1989-12-01,769397,1982
+ADP,Automatic Data Processing,Industrials,Human Resource & Employment Services,"Roseland, New Jersey",1981-03-31,8670,1949
+AZO,AutoZone,Consumer Discretionary,Automotive Retail,"Memphis, Tennessee",1997-01-02,866787,1979
+AVB,AvalonBay Communities,Real Estate,Multi-Family Residential REITs,"Arlington, Virginia",2007-01-10,915912,1978
+AVY,Avery Dennison,Materials,Paper & Plastic Packaging Products & Materials,"Mentor, Ohio",1987-12-31,8818,1990
+AXON,Axon Enterprise,Industrials,Aerospace & Defense,"Scottsdale, Arizona",2023-05-04,1069183,1993
+BKR,Baker Hughes,Energy,Oil & Gas Equipment & Services,"Houston, Texas",2017-07-07,1701605,2017
+BALL,Ball Corporation,Materials,"Metal, Glass & Plastic Containers","Broomfield, Colorado",1984-10-31,9389,1880
+BAC,Bank of America,Financials,Diversified Banks,"Charlotte, North Carolina",1976-06-30,70858,1998 (1923 / 1874)
+BK,Bank of New York Mellon,Financials,Asset Management & Custody Banks,"New York City, New York",1995-03-31,1390777,1784
+BBWI,"Bath & Body Works, Inc.",Consumer Discretionary,Other Specialty Retail,"Columbus, Ohio",1983-09-30,701985,1963
+BAX,Baxter International,Health Care,Health Care Equipment,"Deerfield, Illinois",1972-09-30,10456,1931
+BDX,Becton Dickinson,Health Care,Health Care Equipment,"Franklin Lakes, New Jersey",1972-09-30,10795,1897
+BRK.B,Berkshire Hathaway,Financials,Multi-Sector Holdings,"Omaha, Nebraska",2010-02-16,1067983,1839
+BBY,Best Buy,Consumer Discretionary,Computer & Electronics Retail,"Richfield, Minnesota",1999-06-29,764478,1966
+BIO,Bio-Rad,Health Care,Life Sciences Tools & Services,"Hercules, California",2020-06-22,12208,1952
+TECH,Bio-Techne,Health Care,Life Sciences Tools & Services,"Minneapolis, Minnesota",2021-08-30,842023,1976
+BIIB,Biogen,Health Care,Biotechnology,"Cambridge, Massachusetts",2003-11-13,875045,1978
+BLK,BlackRock,Financials,Asset Management & Custody Banks,"New York City, New York",2011-04-04,1364742,1988
+BX,Blackstone,Financials,Asset Management & Custody Banks,"New York City, New York",2023-09-18,1393818,1985
+BA,Boeing,Industrials,Aerospace & Defense,"Arlington, Virginia",1957-03-04,12927,1916
+BKNG,Booking Holdings,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Norwalk, Connecticut",2009-11-06,1075531,1996
+BWA,BorgWarner,Consumer Discretionary,Automotive Parts & Equipment,"Auburn Hills, Michigan",2011-12-19,908255,1880
+BSX,Boston Scientific,Health Care,Health Care Equipment,"Marlborough, Massachusetts",1995-02-24,885725,1979
+BMY,Bristol Myers Squibb,Health Care,Pharmaceuticals,"New York City, New York",1957-03-04,14272,1989 (1887)
+AVGO,Broadcom,Information Technology,Semiconductors,"Palo Alto, California",2014-05-08,1730168,1961
+BR,Broadridge Financial Solutions,Industrials,Data Processing & Outsourced Services,"Lake Success, New York",2018-06-18,1383312,1962
+BRO,Brown & Brown,Financials,Insurance Brokers,"Daytona Beach, Florida",2021-09-20,79282,1939
+BF.B,Brown–Forman,Consumer Staples,Distillers & Vintners,"Louisville, Kentucky",1982-10-31,14693,1870
+BLDR,Builders FirstSource,Industrials,Building Products,"Irving, Texas",2023-12-18,1316835,1998
+BG,Bunge Global SA,Consumer Staples,Agricultural Products & Services,"Chesterfield, Missouri",2023-03-15,1996862,1818
+BXP,"BXP, Inc.",Real Estate,Office REITs,"Boston, Massachusetts",2006-04-03,1037540,1970
+CDNS,Cadence Design Systems,Information Technology,Application Software,"San Jose, California",2017-09-18,813672,1988
+CZR,Caesars Entertainment,Consumer Discretionary,Casinos & Gaming,"Reno, Nevada",2021-03-22,1590895,1973
+CPT,Camden Property Trust,Real Estate,Multi-Family Residential REITs,"Houston, Texas",2022-04-04,906345,1981
+CPB,Campbell Soup Company,Consumer Staples,Packaged Foods & Meats,"Camden, New Jersey",1957-03-04,16732,1869
+COF,Capital One,Financials,Consumer Finance,"Tysons Corner, Virginia",1998-07-01,927628,1994
+CAH,Cardinal Health,Health Care,Health Care Distributors,"Dublin, Ohio",1997-05-27,721371,1971
+KMX,CarMax,Consumer Discretionary,Automotive Retail,"Richmond, Virginia",2010-06-28,1170010,1993
+CCL,Carnival,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Miami, Florida",1998-12-22,815097,1972
+CARR,Carrier Global,Industrials,Building Products,"Palm Beach Gardens, Florida",2020-04-03,1783180,"2020 (1915, United Technologies spinoff)"
+CTLT,Catalent,Health Care,Pharmaceuticals,"Somerset, New Jersey",2020-09-21,1596783,2007
+CAT,Caterpillar Inc.,Industrials,Construction Machinery & Heavy Transportation Equipment,"Irving, Texas",1957-03-04,18230,1925
+CBOE,Cboe Global Markets,Financials,Financial Exchanges & Data,"Chicago, Illinois",2017-03-01,1374310,1973
+CBRE,CBRE Group,Real Estate,Real Estate Services,"Dallas, Texas",2006-11-10,1138118,1906
+CDW,CDW,Information Technology,Technology Distributors,"Vernon Hills, Illinois",2019-09-23,1402057,1984
+CE,Celanese,Materials,Specialty Chemicals,"Irving, Texas",2018-12-24,1306830,1918
+COR,Cencora,Health Care,Health Care Distributors,"Conshohocken, Pennsylvania",2001-08-30,1140859,1985
+CNC,Centene Corporation,Health Care,Managed Health Care,"St. Louis, Missouri",2016-03-30,1071739,1984
+CNP,CenterPoint Energy,Utilities,Multi-Utilities,"Houston, Texas",1985-07-31,1130310,1882
+CF,CF Industries,Materials,Fertilizers & Agricultural Chemicals,"Deerfield, Illinois",2008-08-27,1324404,1946
+CHRW,CH Robinson,Industrials,Air Freight & Logistics,"Eden Prairie, Minnesota",2007-03-02,1043277,1905
+CRL,Charles River Laboratories,Health Care,Life Sciences Tools & Services,"Wilmington, Massachusetts",2021-05-14,1100682,1947
+SCHW,Charles Schwab Corporation,Financials,Investment Banking & Brokerage,"Westlake, Texas",1997-06-02,316709,1971
+CHTR,Charter Communications,Communication Services,Cable & Satellite,"Stamford, Connecticut",2016-09-08,1091667,1993
+CVX,Chevron Corporation,Energy,Integrated Oil & Gas,"San Ramon, California",1957-03-04,93410,1879
+CMG,Chipotle Mexican Grill,Consumer Discretionary,Restaurants,"Newport Beach, California",2011-04-28,1058090,1993
+CB,Chubb Limited,Financials,Property & Casualty Insurance,"Zurich, Switzerland",2010-07-15,896159,1985
+CHD,Church & Dwight,Consumer Staples,Household Products,"Ewing, New Jersey",2015-12-29,313927,1847
+CI,Cigna,Health Care,Health Care Services,"Bloomfield, Connecticut",1976-06-30,1739940,1982
+CINF,Cincinnati Financial,Financials,Property & Casualty Insurance,"Fairfield, Ohio",1997-12-18,20286,1950
+CTAS,Cintas,Industrials,Diversified Support Services,"Mason, Ohio",2001-03-01,723254,1929
+CSCO,Cisco,Information Technology,Communications Equipment,"San Jose, California",1993-12-01,858877,1984
+C,Citigroup,Financials,Diversified Banks,"New York City, New York",1988-05-31,831001,1998
+CFG,Citizens Financial Group,Financials,Regional Banks,"Providence, Rhode Island",2016-01-29,759944,1828
+CLX,Clorox,Consumer Staples,Household Products,"Oakland, California",1969-03-31,21076,1913
+CME,CME Group,Financials,Financial Exchanges & Data,"Chicago, Illinois",2006-08-11,1156375,1848
+CMS,CMS Energy,Utilities,Multi-Utilities,"Jackson, Michigan",1957-03-04,811156,1886
+KO,Coca-Cola Company (The),Consumer Staples,Soft Drinks & Non-alcoholic Beverages,"Atlanta, Georgia",1957-03-04,21344,1886
+CTSH,Cognizant,Information Technology,IT Consulting & Other Services,"Teaneck, New Jersey",2006-11-17,1058290,1994
+CL,Colgate-Palmolive,Consumer Staples,Household Products,"New York City, New York",1957-03-04,21665,1806
+CMCSA,Comcast,Communication Services,Cable & Satellite,"Philadelphia, Pennsylvania",2002-11-19,1166691,1963
+CAG,Conagra Brands,Consumer Staples,Packaged Foods & Meats,"Chicago, Illinois",1983-08-31,23217,1919
+COP,ConocoPhillips,Energy,Oil & Gas Exploration & Production,"Houston, Texas",1957-03-04,1163165,2002
+ED,Consolidated Edison,Utilities,Multi-Utilities,"New York City, New York",1957-03-04,1047862,1823
+STZ,Constellation Brands,Consumer Staples,Distillers & Vintners,"Rochester, New York",2005-07-01,16918,1945
+CEG,Constellation Energy,Utilities,Electric Utilities,"Baltimore, Maryland",2022-02-02,1868275,1999
+COO,Cooper Companies (The),Health Care,Health Care Supplies,"San Ramon, California",2016-09-23,711404,1958
+CPRT,Copart,Industrials,Diversified Support Services,"Dallas, Texas",2018-07-02,900075,1982
+GLW,Corning Inc.,Information Technology,Electronic Components,"Corning, New York",1995-02-27,24741,1851
+CPAY,Corpay,Financials,Transaction & Payment Processing Services,"Atlanta, Georgia",2018-06-20,1175454,2000
+CTVA,Corteva,Materials,Fertilizers & Agricultural Chemicals,"Indianapolis, Indiana",2019-06-03,1755672,2019
+CSGP,CoStar Group,Real Estate,Real Estate Services,"Washington, D.C.",2022-09-19,1057352,1987
+COST,Costco,Consumer Staples,Consumer Staples Merchandise Retail,"Issaquah, Washington",1993-10-01,909832,1976
+CTRA,Coterra,Energy,Oil & Gas Exploration & Production,"Houston, Texas",2008-06-23,858470,2021 (1989)
+CRWD,CrowdStrike,Information Technology,Systems Software,"Austin, Texas",2024-06-24,1535527,2011
+CCI,Crown Castle,Real Estate,Telecom Tower REITs,"Houston, Texas",2012-03-14,1051470,1994
+CSX,CSX,Industrials,Rail Transportation,"Jacksonville, Florida",1957-03-04,277948,1980
+CMI,Cummins,Industrials,Construction Machinery & Heavy Transportation Equipment,"Columbus, Indiana",1965-03-31,26172,1919
+CVS,CVS Health,Health Care,Health Care Services,"Woonsocket, Rhode Island",1957-03-04,64803,1996
+DHR,Danaher Corporation,Health Care,Life Sciences Tools & Services,"Washington, D.C.",1998-11-18,313616,1969
+DRI,Darden Restaurants,Consumer Discretionary,Restaurants,"Orlando, Florida",1995-05-31,940944,1938
+DVA,DaVita,Health Care,Health Care Services,"Denver, Colorado",2008-07-31,927066,1979
+DAY,Dayforce,Industrials,Human Resource & Employment Services,"Minneapolis, Minnesota",2021-09-20,1725057,1992
+DECK,Deckers Brands,Consumer Discretionary,Footwear,"Goleta, California",2024-03-18,910521,1973
+DE,Deere & Company,Industrials,Agricultural & Farm Machinery,"Moline, Illinois",1957-03-04,315189,1837
+DAL,Delta Air Lines,Industrials,Passenger Airlines,"Atlanta, Georgia",2013-09-11,27904,1929
+DVN,Devon Energy,Energy,Oil & Gas Exploration & Production,"Oklahoma City, Oklahoma",2000-08-30,1090012,1971
+DXCM,Dexcom,Health Care,Health Care Equipment,"San Diego, California",2020-05-12,1093557,1999
+FANG,Diamondback Energy,Energy,Oil & Gas Exploration & Production,"Midland, Texas",2018-12-03,1539838,2007
+DLR,Digital Realty,Real Estate,Data Center REITs,"Austin, Texas",2016-05-18,1297996,2004
+DFS,Discover Financial,Financials,Consumer Finance,"Riverwoods, Illinois",2007-07-02,1393612,1985
+DG,Dollar General,Consumer Staples,Consumer Staples Merchandise Retail,"Goodlettsville, Tennessee",2012-12-03,29534,1939
+DLTR,Dollar Tree,Consumer Staples,Consumer Staples Merchandise Retail,"Chesapeake, Virginia",2011-12-19,935703,1986
+D,Dominion Energy,Utilities,Multi-Utilities,"Richmond, Virginia",2016-11-30,715957,1983
+DPZ,Domino's,Consumer Discretionary,Restaurants,"Ann Arbor, Michigan",2020-05-12,1286681,1960
+DOV,Dover Corporation,Industrials,Industrial Machinery & Supplies & Components,"Downers Grove, Illinois",1985-10-31,29905,1955
+DOW,Dow Inc.,Materials,Commodity Chemicals,"Midland, Michigan",2019-04-01,1751788,2019 (1897)
+DHI,DR Horton,Consumer Discretionary,Homebuilding,"Arlington, Texas",2005-06-22,882184,1978
+DTE,DTE Energy,Utilities,Multi-Utilities,"Detroit, Michigan",1957-03-04,936340,1995
+DUK,Duke Energy,Utilities,Electric Utilities,"Charlotte, North Carolina",1976-06-30,1326160,1904
+DD,DuPont,Materials,Specialty Chemicals,"Wilmington, Delaware",2019-04-02,1666700,2017 (1802)
+EMN,Eastman Chemical Company,Materials,Specialty Chemicals,"Kingsport, Tennessee",1994-01-01,915389,1920
+ETN,Eaton Corporation,Industrials,Electrical Components & Equipment,"Dublin, Ireland",1957-03-04,1551182,1911
+EBAY,eBay,Consumer Discretionary,Broadline Retail,"San Jose, California",2002-07-22,1065088,1995
+ECL,Ecolab,Materials,Specialty Chemicals,"Saint Paul, Minnesota",1989-01-31,31462,1923
+EIX,Edison International,Utilities,Electric Utilities,"Rosemead, California",1957-03-04,827052,1886
+EW,Edwards Lifesciences,Health Care,Health Care Equipment,"Irvine, California",2011-04-01,1099800,1958
+EA,Electronic Arts,Communication Services,Interactive Home Entertainment,"Redwood City, California",2002-07-22,712515,1982
+ELV,Elevance Health,Health Care,Managed Health Care,"Indianapolis, Indiana",2002-07-25,1156039,2014 (1946)
+EMR,Emerson Electric,Industrials,Electrical Components & Equipment,"Ferguson, Missouri",1965-03-31,32604,1890
+ENPH,Enphase,Information Technology,Semiconductor Materials & Equipment,"Fremont, California",2021-01-07,1463101,2006
+ETR,Entergy,Utilities,Electric Utilities,"New Orleans, Louisiana",1957-03-04,65984,1913
+EOG,EOG Resources,Energy,Oil & Gas Exploration & Production,"Houston, Texas",2000-11-02,821189,1999
+EPAM,EPAM Systems,Information Technology,IT Consulting & Other Services,"Newtown, Pennsylvania",2021-12-14,1352010,1993
+EQT,EQT Corporation,Energy,Oil & Gas Exploration & Production,"Pittsburgh, Pennsylvania",2022-10-03,33213,1888
+EFX,Equifax,Industrials,Research & Consulting Services,"Atlanta, Georgia",1997-06-19,33185,1899
+EQIX,Equinix,Real Estate,Data Center REITs,"Redwood City, California",2015-03-20,1101239,1998
+EQR,Equity Residential,Real Estate,Multi-Family Residential REITs,"Chicago, Illinois",2001-12-03,906107,1969
+ESS,Essex Property Trust,Real Estate,Multi-Family Residential REITs,"San Mateo, California",2014-04-02,920522,1971
+EL,Estée Lauder Companies (The),Consumer Staples,Personal Care Products,"New York City, New York",2006-01-05,1001250,1946
+ETSY,Etsy,Consumer Discretionary,Broadline Retail,"New York City, New York",2020-09-21,1370637,2005
+EG,Everest Re,Financials,Reinsurance,"Hamilton, Bermuda",2017-06-19,1095073,1973
+EVRG,Evergy,Utilities,Electric Utilities,"Kansas City, Missouri",2018-06-05,1711269,1909
+ES,Eversource,Utilities,Electric Utilities,"Hartford, Connecticut",2009-07-24,72741,1966
+EXC,Exelon,Utilities,Electric Utilities,"Chicago, Illinois",1957-03-04,1109357,2000
+EXPE,Expedia Group,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Seattle, Washington",2007-10-02,1324424,1996
+EXPD,Expeditors International,Industrials,Air Freight & Logistics,"Seattle, Washington",2007-10-10,746515,1979
+EXR,Extra Space Storage,Real Estate,Self-Storage REITs,"Salt Lake City, Utah",2016-01-19,1289490,1977
+XOM,ExxonMobil,Energy,Integrated Oil & Gas,"Irving, Texas",1957-03-04,34088,1999
+FFIV,"F5, Inc.",Information Technology,Communications Equipment,"Seattle, Washington",2010-12-20,1048695,1996
+FDS,FactSet,Financials,Financial Exchanges & Data,"Norwalk, Connecticut",2021-12-20,1013237,1978
+FICO,Fair Isaac,Information Technology,Application Software,"Bozeman, Montana",2023-03-20,814547,1956
+FAST,Fastenal,Industrials,Trading Companies & Distributors,"Winona, Minnesota",2008-09-15,815556,1967
+FRT,Federal Realty,Real Estate,Retail REITs,"Rockville, Maryland",2016-02-01,34903,1962
+FDX,FedEx,Industrials,Air Freight & Logistics,"Memphis, Tennessee",1980-12-31,1048911,1971
+FIS,Fidelity National Information Services,Financials,Transaction & Payment Processing Services,"Jacksonville, Florida",2006-11-10,1136893,1968
+FITB,Fifth Third Bank,Financials,Diversified Banks,"Cincinnati, Ohio",1996-03-29,35527,1858
+FSLR,First Solar,Information Technology,Semiconductors,"Tempe, Arizona",2022-12-19,1274494,1999
+FE,FirstEnergy,Utilities,Electric Utilities,"Akron, Ohio",1997-11-28,1031296,1997
+FI,Fiserv,Financials,Transaction & Payment Processing Services,"Brookfield, Wisconsin",2001-04-02,798354,1984
+FMC,FMC Corporation,Materials,Fertilizers & Agricultural Chemicals,"Philadelphia, Pennsylvania",2009-08-19,37785,1883
+F,Ford Motor Company,Consumer Discretionary,Automobile Manufacturers,"Dearborn, Michigan",1957-03-04,37996,1903
+FTNT,Fortinet,Information Technology,Systems Software,"Sunnyvale, California",2018-10-11,1262039,2000
+FTV,Fortive,Industrials,Industrial Machinery & Supplies & Components,"Everett, Washington",2016-07-01,1659166,2016
+FOXA,Fox Corporation (Class A),Communication Services,Broadcasting,"New York City, New York",2019-03-04,1754301,2019
+FOX,Fox Corporation (Class B),Communication Services,Broadcasting,"New York City, New York",2019-03-04,1754301,2019
+BEN,Franklin Templeton,Financials,Asset Management & Custody Banks,"San Mateo, California",1998-04-30,38777,1947
+FCX,Freeport-McMoRan,Materials,Copper,"Phoenix, Arizona",2011-07-01,831259,1912
+GRMN,Garmin,Consumer Discretionary,Consumer Electronics,"Schaffhausen, Switzerland",2012-12-12,1121788,1989
+IT,Gartner,Information Technology,IT Consulting & Other Services,"Stamford, Connecticut",2017-04-05,749251,1979
+GE,GE Aerospace,Industrials,Aerospace & Defense,"Evendale, Ohio",1957-03-04,40545,1892
+GEHC,GE HealthCare,Health Care,Health Care Equipment,"Chicago, Illinois",2023-01-04,1932393,1994
+GEV,GE Vernova,Industrials,Heavy Electrical Equipment,"Cambridge, Massachusetts",2024-04-02,1996810,2024
+GEN,Gen Digital,Information Technology,Systems Software,"Tempe, Arizona",2003-03-25,849399,1982
+GNRC,Generac,Industrials,Electrical Components & Equipment,"Waukesha, Wisconsin",2021-03-22,1474735,1959
+GD,General Dynamics,Industrials,Aerospace & Defense,"Falls Church, Virginia",1957-03-04,40533,1899
+GIS,General Mills,Consumer Staples,Packaged Foods & Meats,"Golden Valley, Minnesota",1957-03-04,40704,1856
+GM,General Motors,Consumer Discretionary,Automobile Manufacturers,"Detroit, Michigan",2013-06-06,1467858,1908
+GPC,Genuine Parts Company,Consumer Discretionary,Distributors,"Atlanta, Georgia",1973-12-31,40987,1925
+GILD,Gilead Sciences,Health Care,Biotechnology,"Foster City, California",2004-07-01,882095,1987
+GPN,Global Payments,Financials,Transaction & Payment Processing Services,"Atlanta, Georgia",2016-04-25,1123360,2000
+GL,Globe Life,Financials,Life & Health Insurance,"McKinney, Texas",1989-04-30,320335,1900
+GDDY,GoDaddy,Information Technology,Internet Services & Infrastructure,"Tempe, Arizona",2024-06-24,1609711,1997
+GS,Goldman Sachs,Financials,Investment Banking & Brokerage,"New York City, New York",2002-07-22,886982,1869
+HAL,Halliburton,Energy,Oil & Gas Equipment & Services,"Houston, Texas",1957-03-04,45012,1919
+HIG,Hartford (The),Financials,Property & Casualty Insurance,"Hartford, Connecticut",1957-03-04,874766,1810
+HAS,Hasbro,Consumer Discretionary,Leisure Products,"Pawtucket, Rhode Island",1984-09-30,46080,1923
+HCA,HCA Healthcare,Health Care,Health Care Facilities,"Nashville, Tennessee",2015-01-27,860730,1968
+DOC,Healthpeak,Real Estate,Health Care REITs,"Denver, Colorado",2008-03-31,765880,1985
+HSIC,Henry Schein,Health Care,Health Care Distributors,"Melville, New York",2015-03-17,1000228,1932
+HSY,Hershey's,Consumer Staples,Packaged Foods & Meats,"Hershey, Pennsylvania",1957-03-04,47111,1894
+HES,Hess Corporation,Energy,Integrated Oil & Gas,"New York City, New York",1984-05-31,4447,1919
+HPE,Hewlett Packard Enterprise,Information Technology,"Technology Hardware, Storage & Peripherals","Houston, Texas",2015-11-02,1645590,2015
+HLT,Hilton Worldwide,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Tysons Corner, Virginia",2017-06-19,1585689,1919
+HOLX,Hologic,Health Care,Health Care Equipment,"Marlborough, Massachusetts",2016-03-30,859737,1985
+HD,Home Depot (The),Consumer Discretionary,Home Improvement Retail,"Atlanta, Georgia",1988-03-31,354950,1978
+HON,Honeywell,Industrials,Industrial Conglomerates,"Charlotte, North Carolina",1957-03-04,773840,1906
+HRL,Hormel Foods,Consumer Staples,Packaged Foods & Meats,"Austin, Minnesota",2009-03-04,48465,1891
+HST,Host Hotels & Resorts,Real Estate,Hotel & Resort REITs,"Bethesda, Maryland",2007-03-20,1070750,1993
+HWM,Howmet Aerospace,Industrials,Aerospace & Defense,"Pittsburgh, Pennsylvania",2016-10-21,4281,1888
+HPQ,HP Inc.,Information Technology,"Technology Hardware, Storage & Peripherals","Palo Alto, California",1974-12-31,47217,1939 (2015)
+HUBB,Hubbell Incorporated,Industrials,Industrial Machinery & Supplies & Components,"Shelton, Connecticut",2023-10-18,48898,1888
+HUM,Humana,Health Care,Managed Health Care,"Louisville, Kentucky",2012-12-10,49071,1961
+HBAN,Huntington Bancshares,Financials,Regional Banks,"Columbus, Ohio; Detroit, Michigan",1997-08-28,49196,1866
+HII,Huntington Ingalls Industries,Industrials,Aerospace & Defense,"Newport News, Virginia",2018-01-03,1501585,2011
+IBM,IBM,Information Technology,IT Consulting & Other Services,"Armonk, New York",1957-03-04,51143,1911
+IEX,IDEX Corporation,Industrials,Industrial Machinery & Supplies & Components,"Lake Forest, Illinois",2019-08-09,832101,1988
+IDXX,Idexx Laboratories,Health Care,Health Care Equipment,"Westbrook, Maine",2017-01-05,874716,1983
+ITW,Illinois Tool Works,Industrials,Industrial Machinery & Supplies & Components,"Glenview, Illinois",1986-02-28,49826,1912
+INCY,Incyte,Health Care,Biotechnology,"Wilmington, Delaware",2017-02-28,879169,1991
+IR,Ingersoll Rand,Industrials,Industrial Machinery & Supplies & Components,"Davidson, North Carolina",2020-03-03,1699150,1859
+PODD,Insulet Corporation,Health Care,Health Care Equipment,"Acton, Massachusetts",2023-03-15,1145197,2000
+INTC,Intel,Information Technology,Semiconductors,"Santa Clara, California",1976-12-31,50863,1968
+ICE,Intercontinental Exchange,Financials,Financial Exchanges & Data,"Atlanta, Georgia",2007-09-26,1571949,2000
+IFF,International Flavors & Fragrances,Materials,Specialty Chemicals,"New York City, New York",1976-03-31,51253,1958 (1889)
+IP,International Paper,Materials,Paper & Plastic Packaging Products & Materials,"Memphis, Tennessee",1957-03-04,51434,1898
+IPG,Interpublic Group of Companies (The),Communication Services,Advertising,"New York City, New York",1992-10-01,51644,1961 (1930)
+INTU,Intuit,Information Technology,Application Software,"Mountain View, California",2000-12-05,896878,1983
+ISRG,Intuitive Surgical,Health Care,Health Care Equipment,"Sunnyvale, California",2008-06-02,1035267,1995
+IVZ,Invesco,Financials,Asset Management & Custody Banks,"Atlanta, Georgia",2008-08-21,914208,1935
+INVH,Invitation Homes,Real Estate,Single-Family Residential REITs,"Dallas, Texas",2022-09-19,1687229,2012
+IQV,IQVIA,Health Care,Life Sciences Tools & Services,"Durham, North Carolina",2017-08-29,1478242,1982
+IRM,Iron Mountain,Real Estate,Other Specialized REITs,"Boston, Massachusetts",2009-01-06,1020569,1951
+JBHT,J.B. Hunt,Industrials,Cargo Ground Transportation,"Lowell, Arkansas",2015-07-01,728535,1961
+JBL,Jabil,Information Technology,Electronic Manufacturing Services,"St. Petersburg, Florida",2023-12-18,898293,1966
+JKHY,Jack Henry & Associates,Financials,Transaction & Payment Processing Services,"Monett, Missouri",2018-11-13,779152,1976
+J,Jacobs Solutions,Industrials,Construction & Engineering,"Dallas, Texas",2007-10-26,52988,1947
+JNJ,Johnson & Johnson,Health Care,Pharmaceuticals,"New Brunswick, New Jersey",1973-06-30,200406,1886
+JCI,Johnson Controls,Industrials,Building Products,"Cork, Ireland",2010-08-27,833444,1885
+JPM,JPMorgan Chase,Financials,Diversified Banks,"New York City, New York",1975-06-30,19617,2000 (1799 / 1871)
+JNPR,Juniper Networks,Information Technology,Communications Equipment,"Sunnyvale, California",2006-06-02,1043604,1996
+K,Kellanova,Consumer Staples,Packaged Foods & Meats,"Chicago, Illinois",1989-09-11,55067,1906
+KVUE,Kenvue,Consumer Staples,Personal Care Products,"Skillman, New Jersey",2023-08-25,1944048,2022 (Johnson & Johnson spinoff)
+KDP,Keurig Dr Pepper,Consumer Staples,Soft Drinks & Non-alcoholic Beverages,"Burlington, Massachusetts",2022-06-21,1418135,1981
+KEY,KeyCorp,Financials,Regional Banks,"Cleveland, Ohio",1994-03-01,91576,1825
+KEYS,Keysight,Information Technology,Electronic Equipment & Instruments,"Santa Rosa, California",2018-11-06,1601046,2014 (1939)
+KMB,Kimberly-Clark,Consumer Staples,Household Products,"Irving, Texas",1957-03-04,55785,1872
+KIM,Kimco Realty,Real Estate,Retail REITs,"Jericho, New York",2006-04-04,879101,1958
+KMI,Kinder Morgan,Energy,Oil & Gas Storage & Transportation,"Houston, Texas",2012-05-25,1506307,1997
+KKR,KKR,Financials,Asset Management & Custody Banks,"New York City, New York",2024-06-24,1404912,1976
+KLAC,KLA Corporation,Information Technology,Semiconductor Materials & Equipment,"Milpitas, California",1997-09-30,319201,1975/1977 (1997)
+KHC,Kraft Heinz,Consumer Staples,Packaged Foods & Meats,"Chicago, Illinois; Pittsburgh, Pennsylvania",2015-07-06,1637459,2015 (1869)
+KR,Kroger,Consumer Staples,Food Retail,"Cincinnati, Ohio",1957-03-04,56873,1883
+LHX,L3Harris,Industrials,Aerospace & Defense,"Melbourne, Florida",2008-09-22,202058,"2019 (L3 1997, Harris 1895)"
+LH,LabCorp,Health Care,Health Care Services,"Burlington, North Carolina",2004-11-01,920148,1978
+LRCX,Lam Research,Information Technology,Semiconductor Materials & Equipment,"Fremont, California",2012-06-29,707549,1980
+LW,Lamb Weston,Consumer Staples,Packaged Foods & Meats,"Eagle, Idaho",2018-12-03,1679273,2016 (1950)
+LVS,Las Vegas Sands,Consumer Discretionary,Casinos & Gaming,"Las Vegas, Nevada",2019-10-03,1300514,1988
+LDOS,Leidos,Industrials,Diversified Support Services,"Reston, Virginia",2019-08-09,1336920,1969
+LEN,Lennar,Consumer Discretionary,Homebuilding,"Miami, Florida",2005-10-04,920760,1954
+LLY,Lilly (Eli),Health Care,Pharmaceuticals,"Indianapolis, Indiana",1970-12-31,59478,1876
+LIN,Linde plc,Materials,Industrial Gases,"Guildford, United Kingdom",1992-07-01,1707925,1879
+LYV,Live Nation Entertainment,Communication Services,Movies & Entertainment,"Beverly Hills, California",2019-12-23,1335258,2010
+LKQ,LKQ Corporation,Consumer Discretionary,Distributors,"Chicago, Illinois",2016-05-23,1065696,1998
+LMT,Lockheed Martin,Industrials,Aerospace & Defense,"Bethesda, Maryland",1957-03-04,936468,1995
+L,Loews Corporation,Financials,Multi-line Insurance,"New York City, New York",1995-05-31,60086,1959
+LOW,Lowe's,Consumer Discretionary,Home Improvement Retail,"Mooresville, North Carolina",1984-02-29,60667,1904/1946/1959
+LULU,Lululemon Athletica,Consumer Discretionary,"Apparel, Accessories & Luxury Goods","Vancouver, Canada",2023-10-18,1397187,1998
+LYB,LyondellBasell,Materials,Specialty Chemicals,"Rotterdam, Netherlands",2012-09-05,1489393,2007
+MTB,M&T Bank,Financials,Regional Banks,"Buffalo, New York",2004-02-23,36270,1856
+MRO,Marathon Oil,Energy,Oil & Gas Exploration & Production,"Houston, Texas",1957-03-04,101778,1887
+MPC,Marathon Petroleum,Energy,Oil & Gas Refining & Marketing,"Findlay, Ohio",2011-07-01,1510295,2009 (1887)
+MKTX,MarketAxess,Financials,Financial Exchanges & Data,"New York City, New York",2019-07-01,1278021,2000
+MAR,Marriott International,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Bethesda, Maryland",1998-05-29,1048286,1927
+MMC,Marsh McLennan,Financials,Insurance Brokers,"New York City, New York",1987-08-31,62709,1905
+MLM,Martin Marietta Materials,Materials,Construction Materials,"Raleigh, North Carolina",2014-07-02,916076,1993
+MAS,Masco,Industrials,Building Products,"Livonia, Michigan",1981-06-30,62996,1929
+MA,Mastercard,Financials,Transaction & Payment Processing Services,"Harrison, New York",2008-07-18,1141391,1966
+MTCH,Match Group,Communication Services,Interactive Media & Services,"Dallas, Texas",2021-09-20,891103,1986
+MKC,McCormick & Company,Consumer Staples,Packaged Foods & Meats,"Hunt Valley, Maryland",2003-03-20,63754,1889
+MCD,McDonald's,Consumer Discretionary,Restaurants,"Chicago, Illinois",1970-06-30,63908,1940
+MCK,McKesson Corporation,Health Care,Health Care Distributors,"Irving, Texas",1999-01-13,927653,1833
+MDT,Medtronic,Health Care,Health Care Equipment,"Dublin, Ireland",1986-10-31,1613103,1949
+MRK,Merck & Co.,Health Care,Pharmaceuticals,"Kenilworth, New Jersey",1957-03-04,310158,1891
+META,Meta Platforms,Communication Services,Interactive Media & Services,"Menlo Park, California",2013-12-23,1326801,2004
+MET,MetLife,Financials,Life & Health Insurance,"New York City, New York",2000-12-11,1099219,1868
+MTD,Mettler Toledo,Health Care,Life Sciences Tools & Services,"Columbus, Ohio",2016-09-06,1037646,1945
+MGM,MGM Resorts,Consumer Discretionary,Casinos & Gaming,"Paradise, Nevada",2017-07-26,789570,1986
+MCHP,Microchip Technology,Information Technology,Semiconductors,"Chandler, Arizona",2007-09-07,827054,1989
+MU,Micron Technology,Information Technology,Semiconductors,"Boise, Idaho",1994-09-27,723125,1978
+MSFT,Microsoft,Information Technology,Systems Software,"Redmond, Washington",1994-06-01,789019,1975
+MAA,Mid-America Apartment Communities,Real Estate,Multi-Family Residential REITs,"Memphis, Tennessee",2016-12-02,912595,1977
+MRNA,Moderna,Health Care,Biotechnology,"Cambridge, Massachusetts",2021-07-21,1682852,2010
+MHK,Mohawk Industries,Consumer Discretionary,Home Furnishings,"Calhoun, Georgia",2013-12-23,851968,1878
+MOH,Molina Healthcare,Health Care,Managed Health Care,"Long Beach, California",2022-03-02,1179929,1980
+TAP,Molson Coors Beverage Company,Consumer Staples,Brewers,"Chicago, Illinois",1976-06-30,24545,"2005 (Molson 1786, Coors 1873)"
+MDLZ,Mondelez International,Consumer Staples,Packaged Foods & Meats,"Chicago, Illinois",2012-10-02,1103982,2012
+MPWR,Monolithic Power Systems,Information Technology,Semiconductors,"Kirkland, Washington",2021-02-12,1280452,1997
+MNST,Monster Beverage,Consumer Staples,Soft Drinks & Non-alcoholic Beverages,"Corona, California",2012-06-28,865752,2012 (1935)
+MCO,Moody's Corporation,Financials,Financial Exchanges & Data,"New York City, New York",1998-07-01,1059556,1909
+MS,Morgan Stanley,Financials,Investment Banking & Brokerage,"New York City, New York",1993-07-29,895421,1935
+MOS,Mosaic Company (The),Materials,Fertilizers & Agricultural Chemicals,"Tampa, Florida",2011-09-26,1285785,2004 (1865 / 1909)
+MSI,Motorola Solutions,Information Technology,Communications Equipment,"Chicago, Illinois",1957-03-04,68505,1928 (2011)
+MSCI,MSCI,Financials,Financial Exchanges & Data,"New York City, New York",2018-04-04,1408198,1969
+NDAQ,"Nasdaq, Inc.",Financials,Financial Exchanges & Data,"New York City, New York",2008-10-22,1120193,1971
+NTAP,NetApp,Information Technology,"Technology Hardware, Storage & Peripherals","San Jose, California",1999-06-25,1002047,1992
+NFLX,Netflix,Communication Services,Movies & Entertainment,"Los Gatos, California",2010-12-20,1065280,1997
+NEM,Newmont,Materials,Gold,"Denver, Colorado",1969-06-30,1164727,1921
+NWSA,News Corp (Class A),Communication Services,Publishing,"New York City, New York",2013-08-01,1564708,2013 (News Corporation 1980)
+NWS,News Corp (Class B),Communication Services,Publishing,"New York City, New York",2015-09-18,1564708,2013 (News Corporation 1980)
+NEE,NextEra Energy,Utilities,Multi-Utilities,"Juno Beach, Florida",1976-06-30,753308,1984 (1925)
+NKE,"Nike, Inc.",Consumer Discretionary,"Apparel, Accessories & Luxury Goods","Washington County, Oregon",1988-11-30,320187,1964
+NI,NiSource,Utilities,Multi-Utilities,"Merrillville, Indiana",2000-11-02,1111711,1912
+NDSN,Nordson Corporation,Industrials,Industrial Machinery & Supplies & Components,"Westlake, Ohio",2022-02-15,72331,1935
+NSC,Norfolk Southern Railway,Industrials,Rail Transportation,"Atlanta, Georgia",1957-03-04,702165,1881/1894 (1980)
+NTRS,Northern Trust,Financials,Asset Management & Custody Banks,"Chicago, Illinois",1998-01-30,73124,1889
+NOC,Northrop Grumman,Industrials,Aerospace & Defense,"West Falls Church, Virginia",1957-03-04,1133421,"1994 (Northrop 1939, Grumman 1930)"
+NCLH,Norwegian Cruise Line Holdings,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Miami, Florida",2017-10-13,1513761,2011 (1966)
+NRG,NRG Energy,Utilities,Independent Power Producers & Energy Traders,"Houston, Texas",2010-01-29,1013871,1992
+NUE,Nucor,Materials,Steel,"Charlotte, North Carolina",1985-04-30,73309,1940
+NVDA,Nvidia,Information Technology,Semiconductors,"Santa Clara, California",2001-11-30,1045810,1993
+NVR,"NVR, Inc.",Consumer Discretionary,Homebuilding,"Reston, Virginia",2019-09-26,906163,1980
+NXPI,NXP Semiconductors,Information Technology,Semiconductors,"Eindhoven, Netherlands",2021-03-22,1413447,1953
+ORLY,O'Reilly Auto Parts,Consumer Discretionary,Automotive Retail,"Springfield, Missouri",2009-03-27,898173,1957
+OXY,Occidental Petroleum,Energy,Oil & Gas Exploration & Production,"Houston, Texas",1957-03-04,797468,1920
+ODFL,Old Dominion,Industrials,Cargo Ground Transportation,"Thomasville, North Carolina",2019-12-09,878927,1934
+OMC,Omnicom Group,Communication Services,Advertising,"New York City, New York",1997-12-31,29989,1986
+ON,ON Semiconductor,Information Technology,Semiconductors,"Phoenix, Arizona",2022-06-21,1097864,1999
+OKE,ONEOK,Energy,Oil & Gas Storage & Transportation,"Tulsa, Oklahoma",2010-03-15,1039684,1906
+ORCL,Oracle Corporation,Information Technology,Application Software,"Austin, Texas",1989-08-31,1341439,1977
+OTIS,Otis Worldwide,Industrials,Industrial Machinery & Supplies & Components,"Farmington, Connecticut",2020-04-03,1781335,"2020 (1853, United Technologies spinoff)"
+PCAR,Paccar,Industrials,Construction Machinery & Heavy Transportation Equipment,"Bellevue, Washington",1980-12-31,75362,1905
+PKG,Packaging Corporation of America,Materials,Paper & Plastic Packaging Products & Materials,"Lake Forest, Illinois",2017-07-26,75677,1959
+PANW,Palo Alto Networks,Information Technology,Systems Software,"Santa Clara, California",2023-06-20,1327567,2005
+PARA,Paramount Global,Communication Services,Movies & Entertainment,"New York City, New York",1994-09-30,813828,2019 (Paramount Pictures 1912)
+PH,Parker Hannifin,Industrials,Industrial Machinery & Supplies & Components,"Cleveland, Ohio",1985-11-30,76334,1917
+PAYX,Paychex,Industrials,Human Resource & Employment Services,"Penfield, New York",1998-10-01,723531,1971
+PAYC,Paycom,Industrials,Human Resource & Employment Services,"Oklahoma City, Oklahoma",2020-01-28,1590955,1998
+PYPL,PayPal,Financials,Transaction & Payment Processing Services,"San Jose, California",2015-07-20,1633917,1998
+PNR,Pentair,Industrials,Industrial Machinery & Supplies & Components,"Worsley, United Kingdom",2012-10-01,77360,1966
+PEP,PepsiCo,Consumer Staples,Soft Drinks & Non-alcoholic Beverages,"Purchase, New York",1957-03-04,77476,1898
+PFE,Pfizer,Health Care,Pharmaceuticals,"New York City, New York",1957-03-04,78003,1849
+PCG,PG&E Corporation,Utilities,Multi-Utilities,"San Francisco, California",2022-10-03,1004980,1905
+PM,Philip Morris International,Consumer Staples,Tobacco,"New York City, New York",2008-03-31,1413329,2008 (1847)
+PSX,Phillips 66,Energy,Oil & Gas Refining & Marketing,"Houston, Texas",2012-05-01,1534701,2012 (1917)
+PNW,Pinnacle West,Utilities,Multi-Utilities,"Phoenix, Arizona",1999-10-04,764622,1985
+PNC,PNC Financial Services,Financials,Regional Banks,"Pittsburgh, Pennsylvania",1988-04-30,713676,1845
+POOL,Pool Corporation,Consumer Discretionary,Distributors,"Covington, Louisiana",2020-10-07,945841,1993
+PPG,PPG Industries,Materials,Specialty Chemicals,"Pittsburgh, Pennsylvania",1957-03-04,79879,1883
+PPL,PPL Corporation,Utilities,Electric Utilities,"Allentown, Pennsylvania",2001-10-01,922224,1920
+PFG,Principal Financial Group,Financials,Life & Health Insurance,"Des Moines, Iowa",2002-07-22,1126328,1879
+PG,Procter & Gamble,Consumer Staples,Personal Care Products,"Cincinnati, Ohio",1957-03-04,80424,1837
+PGR,Progressive Corporation,Financials,Property & Casualty Insurance,"Mayfield Village, Ohio",1997-08-04,80661,1937
+PLD,Prologis,Real Estate,Industrial REITs,"San Francisco, California",2003-07-17,1045609,1983
+PRU,Prudential Financial,Financials,Life & Health Insurance,"Newark, New Jersey",2002-07-22,1137774,1875
+PEG,Public Service Enterprise Group,Utilities,Electric Utilities,"Newark, New Jersey",1957-03-04,788784,1903
+PTC,PTC,Information Technology,Application Software,"Boston, Massachusetts",2021-04-20,857005,1985
+PSA,Public Storage,Real Estate,Self-Storage REITs,"Glendale, California",2005-08-19,1393311,1972
+PHM,PulteGroup,Consumer Discretionary,Homebuilding,"Atlanta, Georgia",1984-04-30,822416,1956
+QRVO,Qorvo,Information Technology,Semiconductors,"Greensboro, North Carolina",2015-06-11,1604778,2015
+PWR,Quanta Services,Industrials,Construction & Engineering,"Houston, Texas",2009-07-01,1050915,1997
+QCOM,Qualcomm,Information Technology,Semiconductors,"San Diego, California",1999-07-22,804328,1985
+DGX,Quest Diagnostics,Health Care,Health Care Services,"Secaucus, New Jersey",2002-12-12,1022079,1967
+RL,Ralph Lauren Corporation,Consumer Discretionary,"Apparel, Accessories & Luxury Goods","New York City, New York",2007-02-02,1037038,1967
+RJF,Raymond James,Financials,Investment Banking & Brokerage,"St. Petersburg, Florida",2017-03-20,720005,1962
+RTX,RTX Corporation,Industrials,Aerospace & Defense,"Waltham, Massachusetts",1957-03-04,101829,1922
+O,Realty Income,Real Estate,Retail REITs,"San Diego, California",2015-04-07,726728,1969
+REG,Regency Centers,Real Estate,Retail REITs,"Jacksonville, Florida",2017-03-02,910606,1963
+REGN,Regeneron,Health Care,Biotechnology,"Tarrytown, New York",2013-05-01,872589,1988
+RF,Regions Financial Corporation,Financials,Regional Banks,"Birmingham, Alabama",1998-08-28,1281761,1971
+RSG,Republic Services,Industrials,Environmental & Facilities Services,"Phoenix, Arizona",2008-12-05,1060391,1998 (1981)
+RMD,ResMed,Health Care,Health Care Equipment,"San Diego, California",2017-07-26,943819,1989
+RVTY,Revvity,Health Care,Health Care Equipment,"Waltham, Massachusetts",1985-05-31,31791,1937
+ROK,Rockwell Automation,Industrials,Electrical Components & Equipment,"Milwaukee, Wisconsin",2000-03-12,1024478,1903
+ROL,"Rollins, Inc.",Industrials,Environmental & Facilities Services,"Atlanta, Georgia",2018-10-01,84839,1948
+ROP,Roper Technologies,Information Technology,Electronic Equipment & Instruments,"Sarasota, Florida",2009-12-23,882835,1981
+ROST,Ross Stores,Consumer Discretionary,Apparel Retail,"Dublin, California",2009-12-21,745732,1982
+RCL,Royal Caribbean Group,Consumer Discretionary,"Hotels, Resorts & Cruise Lines","Miami, Florida",2014-12-05,884887,1997
+SPGI,S&P Global,Financials,Financial Exchanges & Data,"New York City, New York",1957-03-04,64040,1917
+CRM,Salesforce,Information Technology,Application Software,"San Francisco, California",2008-09-15,1108524,1999
+SBAC,SBA Communications,Real Estate,Telecom Tower REITs,"Boca Raton, Florida",2017-09-01,1034054,1989
+SLB,Schlumberger,Energy,Oil & Gas Equipment & Services,"Houston, Texas",1957-03-04,87347,1926
+STX,Seagate Technology,Information Technology,"Technology Hardware, Storage & Peripherals","Dublin, Ireland",2012-07-02,1137789,1979
+SRE,Sempra Energy,Utilities,Multi-Utilities,"San Diego, California",2017-03-17,1032208,1998
+NOW,ServiceNow,Information Technology,Systems Software,"Santa Clara, California",2019-11-21,1373715,2003
+SHW,Sherwin-Williams,Materials,Specialty Chemicals,"Cleveland, Ohio",1964-06-30,89800,1866
+SPG,Simon Property Group,Real Estate,Retail REITs,"Indianapolis, Indiana",2002-06-26,1063761,2003
+SWKS,Skyworks Solutions,Information Technology,Semiconductors,"Irvine, California",2015-03-12,4127,2002
+SJM,J.M. Smucker Company (The),Consumer Staples,Packaged Foods & Meats,"Orrville, Ohio",2008-11-06,91419,1897
+SW,Smurfit WestRock,Materials,Paper & Plastic Packaging Products & Materials,"Dublin, Ireland",2024-07-08,2005951,1934
+SNA,Snap-on,Industrials,Industrial Machinery & Supplies & Components,"Kenosha, Wisconsin",1982-09-30,91440,1920
+SOLV,Solventum,Health Care,Health Care Technology,"Saint Paul, Minnesota",2024-04-01,1964738,2023
+SO,Southern Company,Utilities,Electric Utilities,"Atlanta, Georgia",1957-03-04,92122,1945
+LUV,Southwest Airlines,Industrials,Passenger Airlines,"Dallas, Texas",1994-07-01,92380,1967
+SWK,Stanley Black & Decker,Industrials,Industrial Machinery & Supplies & Components,"New Britain, Connecticut",1982-09-30,93556,1843
+SBUX,Starbucks,Consumer Discretionary,Restaurants,"Seattle, Washington",2000-06-07,829224,1971
+STT,State Street Corporation,Financials,Asset Management & Custody Banks,"Boston, Massachusetts",2003-03-14,93751,1792
+STLD,Steel Dynamics,Materials,Steel,"Fort Wayne, Indiana",2022-12-22,1022671,1993
+STE,Steris,Health Care,Health Care Equipment,"Dublin, Ireland",2019-12-23,1757898,1985
+SYK,Stryker Corporation,Health Care,Health Care Equipment,"Kalamazoo, Michigan",2000-12-12,310764,1941
+SMCI,Supermicro,Information Technology,"Technology Hardware, Storage & Peripherals","San Jose, California",2024-03-18,1375365,1993
+SYF,Synchrony Financial,Financials,Consumer Finance,"Stamford, Connecticut",2015-11-18,1601712,2003
+SNPS,Synopsys,Information Technology,Application Software,"Sunnyvale, California",2017-03-16,883241,1986
+SYY,Sysco,Consumer Staples,Food Distributors,"Houston, Texas",1986-12-31,96021,1969
+TMUS,T-Mobile US,Communication Services,Wireless Telecommunication Services,"Bellevue, Washington",2019-07-15,1283699,1994
+TROW,T. Rowe Price,Financials,Asset Management & Custody Banks,"Baltimore, Maryland",2019-07-29,1113169,1937
+TTWO,Take-Two Interactive,Communication Services,Interactive Home Entertainment,"New York City, New York",2018-03-19,946581,1993
+TPR,"Tapestry, Inc.",Consumer Discretionary,"Apparel, Accessories & Luxury Goods","New York City, New York",2004-09-01,1116132,2017
+TRGP,Targa Resources,Energy,Oil & Gas Storage & Transportation,"Houston, Texas",2022-10-12,1389170,2005
+TGT,Target Corporation,Consumer Staples,Consumer Staples Merchandise Retail,"Minneapolis, Minnesota",1976-12-31,27419,1902
+TEL,TE Connectivity,Information Technology,Electronic Manufacturing Services,"Schaffhausen, Switzerland",2011-10-17,1385157,2007
+TDY,Teledyne Technologies,Information Technology,Electronic Equipment & Instruments,"Thousand Oaks, California",2020-06-22,1094285,1960
+TFX,Teleflex,Health Care,Health Care Equipment,"Wayne, Pennsylvania",2019-01-18,96943,1943
+TER,Teradyne,Information Technology,Semiconductor Materials & Equipment,"North Reading, Massachusetts",2020-09-21,97210,1960
+TSLA,"Tesla, Inc.",Consumer Discretionary,Automobile Manufacturers,"Austin, Texas",2020-12-21,1318605,2003
+TXN,Texas Instruments,Information Technology,Semiconductors,"Dallas, Texas",2001-03-12,97476,1930
+TXT,Textron,Industrials,Aerospace & Defense,"Providence, Rhode Island",1978-12-31,217346,1923
+TMO,Thermo Fisher Scientific,Health Care,Life Sciences Tools & Services,"Waltham, Massachusetts",2004-08-03,97745,2006 (1902)
+TJX,TJX Companies,Consumer Discretionary,Apparel Retail,"Framingham, Massachusetts",1985-09-30,109198,1987
+TSCO,Tractor Supply,Consumer Discretionary,Other Specialty Retail,"Brentwood, Tennessee",2014-01-24,916365,1938
+TT,Trane Technologies,Industrials,Building Products,"Dublin, Ireland",2010-11-17,1466258,1871
+TDG,TransDigm Group,Industrials,Aerospace & Defense,"Cleveland, Ohio",2016-06-03,1260221,1993
+TRV,Travelers Companies (The),Financials,Property & Casualty Insurance,"New York City, New York",2002-08-21,86312,1853
+TRMB,Trimble Inc.,Information Technology,Electronic Equipment & Instruments,"Westminster, Colorado",2021-01-21,864749,1978
+TFC,Truist,Financials,Regional Banks,"Charlotte, North Carolina",1997-12-04,92230,1872
+TYL,Tyler Technologies,Information Technology,Application Software,"Plano, Texas",2020-06-22,860731,1966
+TSN,Tyson Foods,Consumer Staples,Packaged Foods & Meats,"Springdale, Arkansas",2005-08-10,100493,1935
+USB,U.S. Bank,Financials,Diversified Banks,"Minneapolis, Minnesota",1999-11-01,36104,1968
+UBER,Uber,Industrials,Passenger Ground Transportation,"San Francisco, California",2023-12-18,1543151,2009
+UDR,"UDR, Inc.",Real Estate,Multi-Family Residential REITs,"Highlands Ranch, Colorado",2016-03-07,74208,1972
+ULTA,Ulta Beauty,Consumer Discretionary,Other Specialty Retail,"Bolingbrook, Illinois",2016-04-18,1403568,1990
+UNP,Union Pacific Corporation,Industrials,Rail Transportation,"Omaha, Nebraska",1957-03-04,100885,1862
+UAL,United Airlines Holdings,Industrials,Passenger Airlines,"Chicago, Illinois",2015-09-03,100517,1967
+UPS,United Parcel Service,Industrials,Air Freight & Logistics,"Sandy Springs, Georgia",2002-07-22,1090727,1907
+URI,United Rentals,Industrials,Trading Companies & Distributors,"Stamford, Connecticut",2014-09-20,1067701,1997
+UNH,UnitedHealth Group,Health Care,Managed Health Care,"Minnetonka, Minnesota",1994-07-01,731766,1977
+UHS,Universal Health Services,Health Care,Health Care Facilities,"King of Prussia, Pennsylvania",2014-09-20,352915,1979
+VLO,Valero Energy,Energy,Oil & Gas Refining & Marketing,"San Antonio, Texas",2002-12-20,1035002,1980
+VTR,Ventas,Real Estate,Health Care REITs,"Chicago, Illinois",2009-03-04,740260,1998
+VLTO,Veralto,Industrials,Environmental & Facilities Services,"Waltham, Massachusetts",2023-10-02,1967680,2023
+VRSN,Verisign,Information Technology,Internet Services & Infrastructure,"Dulles, Virginia",2006-02-01,1014473,1995
+VRSK,Verisk,Industrials,Research & Consulting Services,"Jersey City, New Jersey",2015-10-08,1442145,1971
+VZ,Verizon,Communication Services,Integrated Telecommunication Services,"New York City, New York",1983-11-30,732712,1983 (1877)
+VRTX,Vertex Pharmaceuticals,Health Care,Biotechnology,"Boston, Massachusetts",2013-09-23,875320,1989
+VTRS,Viatris,Health Care,Pharmaceuticals,"Pittsburgh, Pennsylvania",2004-04-23,1792044,1961
+VICI,Vici Properties,Real Estate,Hotel & Resort REITs,"New York City, New York",2022-06-08,1705696,2017
+V,Visa Inc.,Financials,Transaction & Payment Processing Services,"San Francisco, California",2009-12-21,1403161,1958
+VST,Vistra,Utilities,Electric Utilities,"Irving, Texas",2024-05-08,1692819,2016
+VMC,Vulcan Materials Company,Materials,Construction Materials,"Birmingham, Alabama",1999-06-30,1396009,1909
+WRB,W. R. Berkley Corporation,Financials,Property & Casualty Insurance,"Greenwich, Connecticut",2019-12-05,11544,1967
+GWW,W. W. Grainger,Industrials,Industrial Machinery & Supplies & Components,"Lake Forest, Illinois",1981-06-30,277135,1927
+WAB,Wabtec,Industrials,Construction Machinery & Heavy Transportation Equipment,"Pittsburgh, Pennsylvania",2019-02-27,943452,1999 (1869)
+WBA,Walgreens Boots Alliance,Consumer Staples,Drug Retail,"Deerfield, Illinois",1979-12-31,1618921,2014
+WMT,Walmart,Consumer Staples,Consumer Staples Merchandise Retail,"Bentonville, Arkansas",1982-08-31,104169,1962
+DIS,Walt Disney Company (The),Communication Services,Movies & Entertainment,"Burbank, California",1976-06-30,1744489,1923
+WBD,Warner Bros. Discovery,Communication Services,Broadcasting,"New York City, New York",2022-04-11,1437107,2022 (Warner Bros. 1923)
+WM,Waste Management,Industrials,Environmental & Facilities Services,"Houston, Texas",1998-08-31,823768,1968
+WAT,Waters Corporation,Health Care,Life Sciences Tools & Services,"Milford, Massachusetts",2002-01-02,1000697,1958
+WEC,WEC Energy Group,Utilities,Electric Utilities,"Milwaukee, Wisconsin",2008-10-31,783325,1896
+WFC,Wells Fargo,Financials,Diversified Banks,"San Francisco, California",1976-06-30,72971,1852
+WELL,Welltower,Real Estate,Health Care REITs,"Toledo, Ohio",2009-01-30,766704,1970
+WST,West Pharmaceutical Services,Health Care,Health Care Supplies,"Exton, Pennsylvania",2020-05-22,105770,1923
+WDC,Western Digital,Information Technology,"Technology Hardware, Storage & Peripherals","San Jose, California",2009-07-01,106040,1970
+WY,Weyerhaeuser,Real Estate,Timber REITs,"Seattle, Washington",1979-10-01,106535,1900
+WMB,Williams Companies,Energy,Oil & Gas Storage & Transportation,"Tulsa, Oklahoma",1975-03-31,107263,1908
+WTW,Willis Towers Watson,Financials,Insurance Brokers,"London, United Kingdom",2016-01-05,1140536,2016
+WYNN,Wynn Resorts,Consumer Discretionary,Casinos & Gaming,"Paradise, Nevada",2008-11-14,1174922,2002
+XEL,Xcel Energy,Utilities,Multi-Utilities,"Minneapolis, Minnesota",1957-03-04,72903,1909
+XYL,Xylem Inc.,Industrials,Industrial Machinery & Supplies & Components,"White Plains, New York",2011-11-01,1524472,2011
+YUM,Yum! Brands,Consumer Discretionary,Restaurants,"Louisville, Kentucky",1997-10-06,1041061,1997
+ZBRA,Zebra Technologies,Information Technology,Electronic Equipment & Instruments,"Lincolnshire, Illinois",2019-12-23,877212,1969
+ZBH,Zimmer Biomet,Health Care,Health Care Equipment,"Warsaw, Indiana",2001-08-07,1136869,1927
+ZTS,Zoetis,Health Care,Pharmaceuticals,"Parsippany, New Jersey",2013-06-21,1555280,1952

--- a/bro what.py
+++ b/bro what.py
@@ -2,6 +2,31 @@ import sqlite3
 import yfinance as yf
 import csv
 import matplotlib.pyplot as plt  # For visualization
+import os
+import datetime
+from GoogleNews import GoogleNews
+import pandas as pd
+
+class NewsScraper:
+    def __init__(self, lang='en', region='US'):
+        self.googlenews = GoogleNews(lang=lang, region=region)
+
+    def show_news(self, ticker, num_results=5):
+        """Fetch and display top news headlines for the given ticker with clickable hyperlinks."""
+        self.googlenews.search(ticker)
+        results = self.googlenews.results()
+        if not results:
+            print(f"No news found for {ticker}.")
+            return
+
+        print(f"\nTop {num_results} news articles for {ticker}: (ctrl/cmd+click to read in browser)")
+        for news in results[:num_results]:
+            title = news['title']
+            link = news['link']
+            # ANSI escape sequences for hyperlinks (supported in some terminals)
+            hyperlink = f"    \033]8;;{link}\033\\{title}\033]8;;\033\\"
+            print(hyperlink, "\n")
+
 
 class DatabaseManager:
     def __init__(self, db_name="portfolio.db"):
@@ -22,19 +47,19 @@ class DatabaseManager:
                                 FOREIGN KEY(owner_id) REFERENCES users(id))
                             ''')
 
-        self.cursor.execute('''CREATE TABLE IF NOT EXISTS assets (
-                                id INTEGER PRIMARY KEY, 
-                                portfolio_id INTEGER, 
-                                ticker TEXT, 
-                                name TEXT, 
-                                purchase_price REAL, 
+        # Replacing assets with transactions table
+        self.cursor.execute('''CREATE TABLE IF NOT EXISTS transactions (
+                                id INTEGER PRIMARY KEY,
+                                portfolio_id INTEGER,
+                                ticker TEXT,
+                                name TEXT,
+                                transaction_date TEXT,
+                                order_type TEXT,
+                                price REAL,
                                 quantity INTEGER,
-                                market_price REAL,  
-                                pnl REAL,  
-                                order_type TEXT, 
-                                limit_price REAL, 
-                                FOREIGN KEY(portfolio_id) REFERENCES portfolios(id))
-                            ''')
+                                limit_price REAL,
+                                FOREIGN KEY(portfolio_id) REFERENCES portfolios(id)
+                            )''')
         self.conn.commit()
 
     def register_user(self, name):
@@ -52,118 +77,132 @@ class DatabaseManager:
         return user[0] if user else None
 
     def insert_portfolio(self, owner_id, name):
-        self.cursor.execute("INSERT INTO portfolios (owner_id, name) VALUES (?, ?)", (owner_id, name))
+        self.cursor.execute(
+            "INSERT INTO portfolios (owner_id, name) VALUES (?, ?)", (owner_id, name))
         self.conn.commit()
         return self.cursor.lastrowid
 
     def get_market_price(self, ticker):
-        """Fetch the latest market price from Yahoo Finance."""
+        """Fetch the latest market price from Yahoo Finance, or the nearest trading day if today's data is unavailable."""
         try:
             stock = yf.Ticker(ticker)
             stock_data = stock.history(period="1d")
-            if not stock_data.empty:
-                return stock_data["Close"].iloc[-1]
+            if stock_data.empty:
+                # If today's data is missing, search backward for the nearest trading day's data.
+                today = datetime.datetime.today()
+                max_lookback = 10  # look back up to 10 days
+                days_back = 0
+                price = None
+                while days_back < max_lookback:
+                    current_date = today - datetime.timedelta(days=days_back)
+                    next_day = current_date + datetime.timedelta(days=1)
+                    data = stock.history(start=current_date.strftime("%Y-%m-%d"),
+                                            end=next_day.strftime("%Y-%m-%d"))
+                    if not data.empty:
+                        price = data["Close"].iloc[0]
+                        break
+                    days_back += 1
+                if price is None:
+                    print(f"Error fetching market data for {ticker}.")
+                return price
             else:
-                return None
+                return stock_data["Close"].iloc[-1]
         except Exception as e:
             print(f"Error fetching market data for {ticker}: {e}")
             return None
 
-    def insert_asset(self, portfolio_id, ticker, name, purchase_price, quantity, order_type, limit_price=None):
-        """Adds a stock to the portfolio with real-time market price and calculates P&L."""
-        if order_type == 'market':
-            market_price = self.get_market_price(ticker)
-            if market_price is None:
-                print("Error fetching market price. Stock not added.")
+    def get_historical_price(self, ticker, transaction_date):
+        """Fetch the historical market price for a given date, or the nearest previous trading day if not available."""
+        try:
+            stock = yf.Ticker(ticker)
+            date_obj = datetime.datetime.strptime(transaction_date, "%Y-%m-%d")
+            max_lookback = 10  # limit how many days back we search
+            days_back = 0
+            price = None
+            used_date = None
+
+            while days_back < max_lookback:
+                current_date = date_obj - datetime.timedelta(days=days_back)
+                next_day = current_date + datetime.timedelta(days=1)
+                data = stock.history(start=current_date.strftime("%Y-%m-%d"),
+                                     end=next_day.strftime("%Y-%m-%d"))
+                if not data.empty:
+                    price = data["Close"].iloc[0]
+                    used_date = current_date.strftime("%Y-%m-%d")
+                    break
+                days_back += 1
+
+            if price is None:
+                print(
+                    f"Error: No trading data found for {ticker} within {max_lookback} days of {transaction_date}.")
                 return None
-            purchase_price = market_price  # Use market price for purchase
-        elif order_type == 'limit' and limit_price is not None:
-            market_price = limit_price  # Use the provided limit price for purchase
-        else:
-            print("Invalid order type or missing limit price.")
+            if used_date != transaction_date:
+                print(
+                    f"{ticker}: No data on {transaction_date}. Using data from nearest trading day: {used_date}.")
+            return price
+        except Exception as e:
+            print(f"Error fetching historical price for {ticker}: {e}")
             return None
 
-        pnl = (market_price - purchase_price) * quantity
-
-        self.cursor.execute(""" 
-            INSERT INTO assets (portfolio_id, ticker, name, purchase_price, quantity, market_price, pnl, order_type, limit_price) 
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (portfolio_id, ticker, name, purchase_price, quantity, market_price, pnl, order_type, limit_price))
-
+    def insert_transaction(self, portfolio_id, ticker, name, transaction_date, order_type, price, quantity, limit_price=None):
+        """Records a transaction (buy/sell) for the portfolio."""
+        self.cursor.execute(
+            """INSERT INTO transactions (portfolio_id, ticker, name, transaction_date, order_type, price, quantity, limit_price) 
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (portfolio_id, ticker, name, transaction_date, order_type, price, quantity, limit_price))
         self.conn.commit()
         return self.cursor.lastrowid
 
     def check_portfolio(self, portfolio_id):
-        """Displays all assets in a portfolio and updates P&L in real-time."""
-        self.cursor.execute("SELECT id, ticker, name, purchase_price, quantity FROM assets WHERE portfolio_id = ?",
-                            (portfolio_id,))
-        assets = self.cursor.fetchall()
-        if not assets:
-            print("\nNo assets found in this portfolio.")
-            return []
+        """
+        Aggregates transactions to compute current positions.
+        For each ticker, transactions are processed in order (by date) to compute
+        net quantity and the weighted average cost basis.
+        """
+        self.cursor.execute(
+            "SELECT ticker, name, transaction_date, order_type, price, quantity, limit_price FROM transactions WHERE portfolio_id = ? ORDER BY transaction_date, id",
+            (portfolio_id,))
+        transactions = self.cursor.fetchall()
+        if not transactions:
+            print("\nNo transactions found in this portfolio.")
+            return {}
 
-        updated_assets = []
-        for asset in assets:
-            asset_id, ticker, name, purchase_price, quantity = asset
-            market_price = self.get_market_price(ticker)
-            if market_price is None:
-                print(f"Could not retrieve market price for {ticker}.")
-                continue
-
-            pnl = (market_price - purchase_price) * quantity
-            updated_assets.append((asset_id, ticker, name, purchase_price, market_price, quantity, pnl))
-
-            self.cursor.execute("UPDATE assets SET market_price = ?, pnl = ? WHERE id = ?",
-                                (market_price, pnl, asset_id))
-        self.conn.commit()
-
-        return updated_assets
-
-    def update_asset(self, portfolio_id, ticker, purchase_price, quantity, order_type):
-        """Updates the stock's record in the portfolio with the new purchase price and quantity."""
-        self.cursor.execute("SELECT id, purchase_price, quantity FROM assets WHERE portfolio_id = ? AND ticker = ?",
-                            (portfolio_id, ticker))
-        asset = self.cursor.fetchone()
-
-        if asset:
-            asset_id, current_purchase_price, current_quantity = asset
-            new_quantity = current_quantity + quantity  # Update the quantity
-
-            if order_type == 'market':
-                purchase_price = current_purchase_price  # If it's a market order, the price stays the same
-
-            if new_quantity == 0:
-                self.remove_asset(asset_id)
-                print(f"Removed {ticker} from the portfolio.")
+        positions = {}
+        for t in transactions:
+            ticker, name, t_date, order_type, price, quantity, limit_price = t
+            if ticker not in positions:
+                positions[ticker] = {"name": name,
+                                     "quantity": 0, "total_cost": 0.0}
+            # For a buy (quantity positive)
+            if quantity > 0:
+                positions[ticker]["quantity"] += quantity
+                positions[ticker]["total_cost"] += price * quantity
             else:
-                self.cursor.execute("""
-                    UPDATE assets
-                    SET purchase_price = ?, quantity = ?
-                    WHERE id = ?
-                """, (purchase_price, new_quantity, asset_id))
-                print(f"Updated position for {ticker}: {new_quantity} shares at ${purchase_price:.2f} per share.")
-
-            self.conn.commit()
-        else:
-            print(f"No existing asset found for {ticker} in this portfolio.")
-
-    def remove_asset(self, asset_id):
-        """Removes an asset from the portfolio when it is sold."""
-        self.cursor.execute("DELETE FROM assets WHERE id = ?", (asset_id,))
-        self.conn.commit()
+                # For a sell (quantity negative), reduce the position cost basis proportionally.
+                if positions[ticker]["quantity"] > 0:
+                    avg_cost = positions[ticker]["total_cost"] / \
+                        positions[ticker]["quantity"]
+                else:
+                    avg_cost = 0
+                positions[ticker]["quantity"] += quantity
+                positions[ticker]["total_cost"] += avg_cost * \
+                    quantity  # quantity is negative, so cost decreases
+        return positions
 
     def load_valid_tickers(self, filename="SnP_tickers_sector.csv"):
         """
         Loads valid stock tickers and their corresponding asset names and sectors from a CSV file.
-        Expected CSV headers: Symbol, Security, GICS Sector, GICS Sub-Industry, Headquarters Location, Date added, CIK, Founded.
+        Expected CSV headers: Symbol, Security, GICS Sector, ...
         """
         tickers = {}
+        if not os.path.isfile(filename):
+            print(f"Error: File {filename} not found.")
+            return tickers
         try:
             with open(filename, 'r') as file:
                 reader = csv.reader(file)
                 headers = next(reader, None)  # Skip header row if present
                 for row in reader:
-                    # Use the first three columns: Symbol, Security, and GICS Sector.
                     ticker = row[0].strip().upper()
                     name = row[1].strip()
                     sector = row[2].strip() if len(row) > 2 else "Unknown"
@@ -177,6 +216,7 @@ class PortfolioManager:
     def __init__(self):
         self.db = DatabaseManager()
         self.valid_tickers = self.db.load_valid_tickers()
+        self.news_scraper = NewsScraper()  # Instantiate the news scraper
 
     def register(self, name):
         return self.db.register_user(name)
@@ -197,114 +237,230 @@ class PortfolioManager:
             print(f"Error fetching market data for {ticker}: {e}")
             return None
 
+    def get_historical_price(self, ticker, transaction_date):
+        """Fetch the historical market price for a given date."""
+        try:
+            stock = yf.Ticker(ticker)
+            date_obj = datetime.datetime.strptime(transaction_date, "%Y-%m-%d")
+            max_lookback = 10  
+            days_back = 0
+            price = None
+            used_date = None
+
+            while days_back < max_lookback:
+                current_date = date_obj - datetime.timedelta(days=days_back)
+                next_day = current_date + datetime.timedelta(days=1)
+                data = stock.history(start=current_date.strftime("%Y-%m-%d"),
+                                     end=next_day.strftime("%Y-%m-%d"))
+                if not data.empty:
+                    price = data["Close"].iloc[0]
+                    used_date = current_date.strftime("%Y-%m-%d")
+                    break
+                days_back += 1
+
+            if price is None:
+                print(
+                    f"Error: No trading data found for {ticker} within {max_lookback} days of {transaction_date}.")
+                return None
+            if used_date != transaction_date:
+                print(
+                    f"{ticker}: No data on {transaction_date}. Using data from nearest trading day: {used_date}.")
+            return price
+        except Exception as e:
+            print(f"Error fetching historical price for {ticker}: {e}")
+            return None
+
     def create_portfolio(self, owner_id, name):
-        self.db.cursor.execute("SELECT id FROM portfolios WHERE owner_id = ?", (owner_id,))
+        self.db.cursor.execute(
+            "SELECT id FROM portfolios WHERE owner_id = ?", (owner_id,))
         existing_portfolio = self.db.cursor.fetchone()
 
         if existing_portfolio:
-            print(f"User already has a portfolio with ID {existing_portfolio[0]}.")
+            print(
+                f"User already has a portfolio with ID {existing_portfolio[0]}.")
             return existing_portfolio[0]
         else:
             return self.db.insert_portfolio(owner_id, name)
 
-    def update_stock_in_portfolio(self, portfolio_id, ticker, purchase_price, quantity, order_type, limit_price=None):
-        """Update the stock's record in the portfolio, either buying more or shorting more."""
-        self.db.cursor.execute("SELECT quantity, purchase_price FROM assets WHERE portfolio_id = ? AND ticker = ?", (portfolio_id, ticker))
-        existing_asset = self.db.cursor.fetchone()
-
-        if existing_asset:
-            self.db.update_asset(portfolio_id, ticker, purchase_price, quantity, order_type)
-        else:
-            # Look up the asset name from our valid tickers; default to 'Unknown' if not found.
-            asset_info = self.valid_tickers.get(ticker, {"name": "Unknown"})
-            self.db.insert_asset(portfolio_id, ticker, asset_info.get("name", "Unknown"), purchase_price, quantity, order_type, limit_price)
-            print(f"New position added for {ticker}: {quantity} shares.")
-
-    def buy_stock(self, portfolio_id, ticker, name, purchase_price, quantity, order_type, limit_price=None):
-        """Insert the new stock into the portfolio after buying."""
-        self.db.insert_asset(portfolio_id, ticker, name, purchase_price, quantity, order_type, limit_price)
-        print(f"Successfully bought {quantity} of {name} ({ticker}) at ${purchase_price:.2f} per share.")
-
     def buy_loop(self, portfolio_id):
         while True:
-            ticker = input("Enter stock ticker (or type 'exit' to quit): ").upper()
+            ticker = input(
+                "Enter stock ticker (or type 'exit' to quit): ").upper()
             if ticker == "EXIT":
                 break
+
             if ticker in self.valid_tickers:
                 asset_name = self.valid_tickers[ticker]["name"]
                 market_price = self.get_market_price(ticker)
                 if market_price is None:
-                    print(f"Could not retrieve market price for {ticker}. Please try again.")
+                    print(
+                        f"Could not retrieve market price for {ticker}. Please try again.")
                     continue
 
                 print(f"\nStock found: {ticker} - {asset_name}")
                 print(f"Current market price: ${market_price:.2f}")
-                confirm = input(f"Do you want to buy {asset_name} ({ticker})? (y/n): ").lower()
 
+                view_news = input(
+                    "Would you like to view recent news for this stock? (y/n): ").lower()
+                if view_news == 'y':
+                    self.news_scraper.show_news(asset_name)
+
+                confirm = input(
+                    f"Do you want to buy {asset_name} ({ticker})? (y/n): ").lower()
                 if confirm == 'y':
-                    order_type = input("Enter order type (market/limit): ").lower()
-                    if order_type == 'limit':
-                        limit_price = float(input("Enter limit price: "))
-                        self.update_stock_in_portfolio(portfolio_id, ticker, None, 0, order_type, limit_price)
-                    elif order_type == 'market':
-                        purchase_price = market_price
+                    historical = input(
+                        "Do you want to record a historical transaction? (y/n): ").lower()
+                    if historical == 'y':
+                        transaction_date = input(
+                            "Enter transaction date (YYYY-MM-DD): ")
+                        order_type = input(
+                            "Enter order type (market/limit): ").lower()
+                        if order_type == 'limit':
+                            limit_price = float(input("Enter limit price: "))
+                            price = limit_price
+                        elif order_type == 'market':
+                            price = self.get_historical_price(
+                                ticker, transaction_date)
+                            if price is None:
+                                print(
+                                    "Error fetching historical market price. Transaction canceled.")
+                                continue
+                            limit_price = None
+                        else:
+                            print("Invalid order type. Please try again.")
+                            continue
                         quantity = int(input("Enter quantity: "))
-                        self.update_stock_in_portfolio(portfolio_id, ticker, purchase_price, quantity, order_type)
-                    break
+                        self.db.insert_transaction(
+                            portfolio_id, ticker, asset_name, transaction_date, order_type, price, quantity, limit_price)
+                        print(
+                            f"Recorded historical purchase of {quantity} shares of {ticker} on {transaction_date} at ${price:.2f}.")
+                    else:
+                        # Record a current transaction using today's date.
+                        from datetime import date
+                        transaction_date = str(date.today())
+                        order_type = input(
+                            "Enter order type (market/limit): ").lower()
+                        if order_type == 'limit':
+                            limit_price = float(input("Enter limit price: "))
+                            price = limit_price
+                        elif order_type == 'market':
+                            price = market_price
+                            limit_price = None
+                        else:
+                            print("Invalid order type. Please try again.")
+                            continue
+                        quantity = int(input("Enter quantity: "))
+                        self.db.insert_transaction(
+                            portfolio_id, ticker, asset_name, transaction_date, order_type, price, quantity, limit_price)
+                        print(
+                            f"Successfully recorded purchase of {quantity} shares of {ticker} at ${price:.2f} on {transaction_date}.")
                 else:
-                    print("\nYou chose not to buy. Here are some suggested tickers based on your input:")
-                    self.validate_ticker(ticker)
+                    print("Buy transaction canceled.")
             else:
                 print("\nNo matching ticker found. Here are some suggested tickers:")
                 self.validate_ticker(ticker)
 
     def check_portfolio(self, portfolio_id):
-        assets = self.db.check_portfolio(portfolio_id)
-        if assets:
+        positions = self.db.check_portfolio(portfolio_id)
+        if positions:
             print("\nCurrent Portfolio Holdings:")
-            for asset in assets:
-                asset_id, ticker, name, purchase_price, market_price, quantity, pnl = asset
+            for ticker, data in positions.items():
+                quantity = data["quantity"]
+                if quantity == 0:
+                    continue
+                avg_price = data["total_cost"] / \
+                    quantity if quantity != 0 else 0
+                market_price = self.get_market_price(ticker)
+                if market_price is None:
+                    print(f"Could not retrieve market price for {ticker}.")
+                    continue
                 if quantity > 0:
-                    print(f"Owned: {name} ({ticker}) - Purchase: ${purchase_price:.2f}, Market: ${market_price:.2f}, Quantity: {quantity}, P&L: ${pnl:.2f}")
+                    pnl = (market_price - avg_price) * quantity
+                    print(
+                        f"Owned: {data['name']} ({ticker}) - Avg Purchase: ${avg_price:.2f}, Market: ${market_price:.2f}, Quantity: {quantity}, P&L: ${pnl:.2f}")
                 else:
-                    short_pnl = (purchase_price - market_price) * abs(quantity)
-                    print(f"Short: {name} ({ticker}) - Sale: ${purchase_price:.2f}, Market: ${market_price:.2f}, Quantity: {quantity}, P&L: ${short_pnl:.2f}")
-        return assets
+                    pnl = (avg_price - market_price) * abs(quantity)
+                    print(
+                        f"Short: {data['name']} ({ticker}) - Avg Sale: ${avg_price:.2f}, Market: ${market_price:.2f}, Quantity: {quantity}, P&L: ${pnl:.2f}")
+        else:
+            print("No transactions to display.")
 
     def sell_asset_loop(self, portfolio_id):
         while True:
-            ticker = input("Enter stock ticker to short (or type 'exit' to quit): ").upper()
+            ticker = input(
+                "Enter stock ticker to sell/short (or type 'exit' to quit): ").upper()
             if ticker == "EXIT":
                 break
             if ticker in self.valid_tickers:
                 asset_name = self.valid_tickers[ticker]["name"]
                 market_price = self.get_market_price(ticker)
                 if market_price is None:
-                    print(f"Could not retrieve market price for {ticker}. Please try again.")
+                    print(
+                        f"Could not retrieve market price for {ticker}. Please try again.")
                     continue
 
                 print(f"\nAsset found: {asset_name} ({ticker})")
                 print(f"Current market price: ${market_price:.2f}")
-                confirm = input(f"Do you want to short sell {asset_name} ({ticker})? (y/n): ").lower()
+                confirm = input(
+                    f"Do you want to sell/short {asset_name} ({ticker})? (y/n): ").lower()
                 if confirm == 'y':
-                    order_type = input("Enter order type (market/limit): ").lower()
-                    if order_type == 'limit':
-                        limit_price = float(input("Enter limit price: "))
-                        self.update_stock_in_portfolio(portfolio_id, ticker, None, -1, order_type, limit_price)
-                    elif order_type == 'market':
-                        quantity = int(input("Enter quantity to short: "))
-                        self.update_stock_in_portfolio(portfolio_id, ticker, market_price, -quantity, order_type)
-                    print(f"Successfully shorted {quantity} of {asset_name} ({ticker}) at ${market_price:.2f} per share.")
-                    break
+                    historical = input(
+                        "Do you want to record a historical transaction? (y/n): ").lower()
+                    if historical == 'y':
+                        transaction_date = input(
+                            "Enter transaction date (YYYY-MM-DD): ")
+                        order_type = input(
+                            "Enter order type (market/limit): ").lower()
+                        if order_type == 'limit':
+                            limit_price = float(input("Enter limit price: "))
+                            price = limit_price
+                        elif order_type == 'market':
+                            price = self.get_historical_price(
+                                ticker, transaction_date)
+                            if price is None:
+                                print(
+                                    "Error fetching historical market price. Transaction canceled.")
+                                continue
+                            limit_price = None
+                        else:
+                            print("Invalid order type. Please try again.")
+                            continue
+                        quantity = int(input("Enter quantity to sell/short: "))
+                        # Record the sale/short as a negative quantity.
+                        self.db.insert_transaction(
+                            portfolio_id, ticker, asset_name, transaction_date, order_type, price, -quantity, limit_price)
+                        print(
+                            f"Recorded historical sale/short of {quantity} shares of {ticker} on {transaction_date} at ${price:.2f}.")
+                    else:
+                        from datetime import date
+                        transaction_date = str(date.today())
+                        order_type = input(
+                            "Enter order type (market/limit): ").lower()
+                        if order_type == 'limit':
+                            limit_price = float(input("Enter limit price: "))
+                            price = limit_price
+                        elif order_type == 'market':
+                            price = market_price
+                            limit_price = None
+                        else:
+                            print("Invalid order type. Please try again.")
+                            continue
+                        quantity = int(input("Enter quantity to sell/short: "))
+                        self.db.insert_transaction(
+                            portfolio_id, ticker, asset_name, transaction_date, order_type, price, -quantity, limit_price)
+                        print(
+                            f"Successfully recorded sale/short of {quantity} shares of {ticker} at ${price:.2f} on {transaction_date}.")
+                        break
                 else:
-                    print("Short sale canceled.")
+                    print("Sell/Short transaction canceled.")
             else:
                 print("\nNo matching ticker found. Here are some suggested tickers:")
                 self.validate_ticker(ticker)
 
     def validate_ticker(self, ticker):
         """Suggests matching tickers for a given partial input."""
-        matches = [valid_ticker for valid_ticker in self.valid_tickers if valid_ticker.startswith(ticker.upper())]
+        matches = [valid_ticker for valid_ticker in self.valid_tickers if valid_ticker.startswith(
+            ticker.upper())]
         if matches:
             print("Matching tickers:")
             for match in matches:
@@ -315,60 +471,187 @@ class PortfolioManager:
 
     def export_portfolio(self, portfolio_id, filename="portfolio_export.csv"):
         """Exports the portfolio details to a CSV file."""
-        assets = self.db.check_portfolio(portfolio_id)
-        if assets:
+        positions = self.db.check_portfolio(portfolio_id)
+        if positions:
             try:
                 with open(filename, "w", newline="") as csvfile:
                     writer = csv.writer(csvfile)
-                    writer.writerow(["Asset ID", "Ticker", "Name", "Purchase Price", "Market Price", "Quantity", "PnL"])
-                    for asset in assets:
-                        writer.writerow(asset)
+                    writer.writerow(
+                        ["Ticker", "Name", "Quantity", "Avg Purchase Price"])
+                    for ticker, data in positions.items():
+                        if data["quantity"] != 0:
+                            avg_price = data["total_cost"] / data["quantity"]
+                            writer.writerow(
+                                [ticker, data["name"], data["quantity"], avg_price])
                 print(f"Portfolio exported to {filename}")
             except Exception as e:
                 print(f"Error exporting portfolio: {e}")
         else:
-            print("No assets to export.")
+            print("No transactions to export.")
+    
 
-    def visualize_portfolio(self, portfolio_id):
-        """Visualizes the portfolio performance with a bar chart showing current values."""
-        assets = self.db.check_portfolio(portfolio_id)
-        if not assets:
-            print("No assets to visualize.")
+
+    def visualise_portfolio(self, portfolio_id):
+        """
+        Creates a side-by-side visualization:
+        - Left: A bar chart showing current portfolio performance (using check_portfolio).
+        - Right: A time series chart displaying, over time, total portfolio value, net deposits, and total returns.
+        """
+        # ----- Left: Current Portfolio Bar Chart -----
+
+        def _get_price_from_series(series, current_date):
+            """
+            Given a DataFrame of historical data (with a DateTimeIndex and 'Close' column)
+            and a current_date (datetime.date), returns the as-of closing price.
+            """
+            ts = pd.Timestamp(current_date)
+            price = series['Close'].asof(ts)
+            # If asof returns a Series, get the first element
+            if isinstance(price, pd.Series):
+                price = price.iloc[0]
+            return price
+        def _fetch_time_series(ticker, start_date, end_date, interval="1d"):
+            """
+            Fetches the full time series for a ticker using yf.download.
+            If no data is returned for the provided end_date, it adjusts the end_date backward until data is found.
+            Returns a DataFrame.
+            """
+            data = yf.download(ticker, start=start_date,
+                            end=end_date, interval=interval)
+            original_end = end_date
+            while data.empty:
+                end_dt = datetime.datetime.strptime(
+                    end_date, "%Y-%m-%d") - datetime.timedelta(days=1)
+                end_date = end_dt.strftime("%Y-%m-%d")
+                if end_date <= start_date:
+                    break
+                data = yf.download(ticker, start=start_date,
+                                end=end_date, interval=interval)
+            if data.empty:
+                print(
+                    f"Error: No data found for {ticker} from {start_date} to {original_end}.")
+            return data
+        positions = self.db.check_portfolio(portfolio_id)
+        tickers = []
+        current_values = []
+        for ticker, data in positions.items():
+            if data["quantity"] == 0:
+                continue
+            market_price = self.get_market_price(ticker)
+            if market_price is None:
+                continue
+            tickers.append(ticker)
+            current_values.append(market_price * data["quantity"])
+
+        # ----- Right: Time Series Chart -----
+        # Retrieve all transactions (ordered by date)
+        self.db.cursor.execute(
+            "SELECT transaction_date, ticker, price, quantity FROM transactions WHERE portfolio_id = ? ORDER BY transaction_date, id",
+            (portfolio_id,))
+        transactions = self.db.cursor.fetchall()
+        if not transactions:
+            print("No transactions found for time series visualization.")
             return
 
-        tickers = []
-        values = []
-        for asset in assets:
-            asset_id, ticker, name, purchase_price, market_price, quantity, pnl = asset
-            tickers.append(ticker)
-            values.append(market_price * quantity)
+        # Parse transactions into a list of (date, ticker, price, quantity)
+        transactions_parsed = []
+        for t in transactions:
+            trans_date = datetime.datetime.strptime(t[0], "%Y-%m-%d").date()
+            transactions_parsed.append((trans_date, t[1], t[2], t[3]))
 
-        plt.figure(figsize=(10, 6))
-        plt.bar(tickers, values, color='skyblue')
-        plt.xlabel('Ticker')
-        plt.ylabel('Current Value ($)')
-        plt.title('Portfolio Performance')
+        # Determine overall date range: earliest transaction date to today
+        start_date = min(t[0] for t in transactions_parsed)
+        end_date = datetime.date.today()
+        date_list = [start_date + datetime.timedelta(days=i)
+                    for i in range((end_date - start_date).days + 1)]
+
+        # Pre-fetch time series data for each ticker involved
+        ticker_series = {}
+        start_str = start_date.strftime("%Y-%m-%d")
+        # yf.download uses an exclusive end date; add one day to include today
+        end_str = (end_date + datetime.timedelta(days=1)).strftime("%Y-%m-%d")
+        tickers_involved = set(t[1] for t in transactions_parsed)
+        for ticker in tickers_involved:
+            ts_data = _fetch_time_series(ticker, start_str, end_str, interval="1d")
+            if not ts_data.empty:
+                ts_data.index = pd.to_datetime(ts_data.index)
+                ticker_series[ticker] = ts_data
+            else:
+                print(f"Warning: No historical data for {ticker}.")
+
+        ts_dates = []
+        total_values = []
+        net_deposits_list = []
+        total_returns_list = []
+        for current_date in date_list:
+            # Compute cumulative net deposits and positions up to current_date
+            net_deposits = 0.0
+            positions_ts = {}
+            for trans in transactions_parsed:
+                if trans[0] <= current_date:
+                    net_deposits += trans[2] * trans[3]
+                    positions_ts[trans[1]] = positions_ts.get(
+                        trans[1], 0) + trans[3]
+            portfolio_value = 0.0
+            for ticker, quantity in positions_ts.items():
+                if quantity == 0:
+                    continue
+                if ticker in ticker_series:
+                    price = _get_price_from_series(
+                        ticker_series[ticker], current_date)
+                    if pd.isna(price):
+                        price = ticker_series[ticker]['Close'].dropna().iloc[-1]
+                    if price is not None:
+                        portfolio_value += price * quantity
+            total_return = portfolio_value - net_deposits
+            ts_dates.append(current_date)
+            total_values.append(portfolio_value)
+            net_deposits_list.append(net_deposits)
+            total_returns_list.append(total_return)
+
+        # ----- Plotting Side by Side -----
+        fig, axes = plt.subplots(1, 2, figsize=(16, 6))
+
+        # Left subplot: Current Portfolio Bar Chart
+        axes[0].bar(tickers, current_values, color='skyblue')
+        axes[0].set_xlabel("Ticker")
+        axes[0].set_ylabel("Current Value ($)")
+        axes[0].set_title("Portfolio Current Performance")
+
+        # Right subplot: Time Series Chart
+        axes[1].plot(ts_dates, total_values, label="Total Value")
+        axes[1].plot(ts_dates, net_deposits_list, label="Net Deposits")
+        axes[1].plot(ts_dates, total_returns_list, label="Total Returns")
+        axes[1].set_xlabel("Date")
+        axes[1].set_ylabel("Amount ($)")
+        axes[1].set_title("Portfolio Performance Over Time")
+        axes[1].legend()
+
         plt.tight_layout()
         plt.show()
+
+        
 
     def diversification_analysis(self, portfolio_id):
         """
         Analyzes diversification by computing the current value per sector.
         Uses the 'GICS Sector' from the CSV file and displays a breakdown and pie chart.
         """
-        assets = self.db.check_portfolio(portfolio_id)
-        if not assets:
-            print("No assets to analyze for diversification.")
+        positions = self.db.check_portfolio(portfolio_id)
+        if not positions:
+            print("No transactions to analyze for diversification.")
             return
 
         sector_values = {}
         total_value = 0
-        for asset in assets:
-            asset_id, ticker, name, purchase_price, market_price, quantity, pnl = asset
-            value = market_price * quantity
+        for ticker, data in positions.items():
+            if data["quantity"] == 0:
+                continue
+            market_price = self.get_market_price(ticker)
+            if market_price is None:
+                continue
+            value = market_price * data["quantity"]
             total_value += value
-
-            # Lookup the sector from valid tickers; default to "Unknown" if missing.
             if ticker in self.valid_tickers:
                 sector = self.valid_tickers[ticker].get("sector", "Unknown")
             else:
@@ -380,7 +663,6 @@ class PortfolioManager:
             percentage = (value / total_value * 100) if total_value != 0 else 0
             print(f"{sector}: ${value:.2f} ({percentage:.2f}%)")
 
-        # Pie chart visualization for diversification.
         labels = list(sector_values.keys())
         sizes = [value for value in sector_values.values()]
         plt.figure(figsize=(8, 8))
@@ -388,6 +670,8 @@ class PortfolioManager:
         plt.title("Portfolio Diversification by Sector")
         plt.axis('equal')
         plt.show()
+
+    
 
 
 if __name__ == "__main__":
@@ -400,21 +684,21 @@ if __name__ == "__main__":
     portfolio_id = manager.create_portfolio(user_id, portfolio_name)
 
     while True:
-        print("\nOptions: 1) Buy Stock  2) Check Portfolio  3) Short Sell Stock  4) Export Portfolio  5) Visualize Portfolio  6) Diversification Analysis  7) Exit")
+        print("\nOptions: \n1) Buy Stock   \n2) Sell/Short Sell Stock \n3) Check Portfolio   \n4) Visualize Portfolio  \n5) Diversification Analysis  \n6) Export Portfolio \n7) Exit")
         choice = input("Enter choice: ")
 
         if choice == "1":
             manager.buy_loop(portfolio_id)
         elif choice == "2":
-            manager.check_portfolio(portfolio_id)
-        elif choice == "3":
             manager.sell_asset_loop(portfolio_id)
+        elif choice == "3":
+            manager.check_portfolio(portfolio_id)
         elif choice == "4":
-            manager.export_portfolio(portfolio_id)
+            manager.visualise_portfolio(portfolio_id)
         elif choice == "5":
-            manager.visualize_portfolio(portfolio_id)
-        elif choice == "6":
             manager.diversification_analysis(portfolio_id)
+        elif choice == "6":
+            manager.export_portfolio(portfolio_id)
         elif choice == "7":
             print("Exiting...")
             break

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+GoogleNews==1.6.15
+GoogleNews==1.6.15
+matplotlib==3.7.2
+pandas==1.5.0
+yfinance==0.2.54


### PR DESCRIPTION
to run make sure you have the snp tickers csv, and run pip install -r requirements.txt (for latest yfinance & GoogleNews). delete old portfolio db if there is an error.

- added requirements.txt and csv
- added news scraper with google news
- changed assets to transactions stored in db
- added option to add historical transactions; users specify date and system fetches nearest historical market price
- added time series visualisation of portfolio value, deposits and total returns
- rearraged menu and options on newlines

#TODO
- portfolio metrics - sharpe ratio, volatility etc.
- more error handling e.g. non-trading days check
- short positions should have a different time series viz? long vs short performance trends
- stock explorer by industry or metric like market cap / P/E ratio